### PR TITLE
Refactor path solvers into pluggable classes

### DIFF
--- a/Assets/Scripts/MultiThreadedSolver.cs
+++ b/Assets/Scripts/MultiThreadedSolver.cs
@@ -22,6 +22,7 @@ public class MultiStrategyAnimator : MonoBehaviour
     ConcurrentQueue<Vector2Int>[] visitQueues;
     ConcurrentQueue<Vector2Int>[] pathQueues;
     int winnerIdx = -1;
+    List<IPathSolver> solvers;
 
     void Start()
     {
@@ -34,22 +35,31 @@ public class MultiStrategyAnimator : MonoBehaviour
         if (overlayShader == null)
             overlayShader = Shader.Find("Unlit/Color");
 
-        int N = 5;
+        solvers = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .Where(t => typeof(IPathSolver).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+            .Select(t => (IPathSolver)Activator.CreateInstance(t))
+            .ToList();
+
+        int N = solvers.Count;
         cts = new CancellationTokenSource();
         visitQueues = new ConcurrentQueue<Vector2Int>[N];
         pathQueues = new ConcurrentQueue<Vector2Int>[N];
 
-        // fixed colors per solver
-        threadColors = new Color[]
+        Color[] baseColors =
         {
-    Color.yellow,    // BFS
-    Color.red,       // DFS
-    new Color(0.5f,0f,0.5f), // Greedy
-    Color.blue,      // RandomWalk
-new Color(1f, 0.5f, 0f)
+            Color.yellow,
+            Color.red,
+            new Color(0.5f,0f,0.5f),
+            Color.blue,
+            new Color(1f, 0.5f, 0f)
         };
-        string[] names = { "BFS", "DFS", "Greedy", "RandomWalk", "A*" };
-        string[] colorNames = { "Yellow", "Red", "Purple", "Blue", "Orange" };
+        threadColors = new Color[N];
+        for (int i = 0; i < N; i++)
+            threadColors[i] = i < baseColors.Length ? baseColors[i] : UnityEngine.Random.ColorHSV();
+
+        string[] names = solvers.Select(s => s.GetType().Name).ToArray();
+        string[] colorNames = threadColors.Select(c => ColorUtility.ToHtmlStringRGB(c)).ToArray();
 
         // init queues
         for (int i = 0; i < N; i++)
@@ -63,11 +73,20 @@ new Color(1f, 0.5f, 0f)
             Debug.Log($"Solver {i}: {names[i]} → Color {colorNames[i]}");
 
         // launch solver tasks
-        //Task.Run(() => RunBFS(0, maze, start, goal, cts.Token));
-        //Task.Run(() => RunDFS(1, maze, start, goal, cts.Token));
-        //Task.Run(() => RunGreedy(2, maze, start, goal, cts.Token));
-        //Task.Run(() => RunRandomWalk(3, maze, start, goal, cts.Token));
-        //Task.Run(() => RunAStar(4, maze, start, goal, cts.Token));
+        for (int i = 0; i < N; i++)
+        {
+            int idx = i;
+            solvers[idx]
+                .Solve(maze, start, goal, cts.Token, visitQueues[idx], pathQueues[idx])
+                .ContinueWith(_ =>
+                {
+                    if (pathQueues[idx].Count > 0 && winnerIdx < 0)
+                    {
+                        winnerIdx = idx;
+                        cts.Cancel();
+                    }
+                });
+        }
         // start animation coroutines
         for (int i = 0; i < N; i++)
             StartCoroutine(Animate(i));
@@ -82,7 +101,7 @@ new Color(1f, 0.5f, 0f)
         while (winnerIdx < 0)
             yield return null;
 
-        string[] names = { "BFS", "DFS", "Greedy", "RandomWalk" };
+        string[] names = solvers.Select(s => s.GetType().Name).ToArray();
         string msg = $"🎉 WINNER: Solver {winnerIdx} ({names[winnerIdx]}) 🎉";
         Debug.Log(msg);
 
@@ -98,291 +117,6 @@ new Color(1f, 0.5f, 0f)
         textGO.transform.position = new Vector3(0, H / 2f + 1f, -0.5f);
     }
 
-    // 1) BFS
-    void RunBFS(int idx, int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok)
-    {
-        int W = maze.GetLength(0), H = maze.GetLength(1);
-        var visited = new bool[W, H];
-        var parent = new Dictionary<Vector2Int, Vector2Int>();
-        var q = new Queue<Vector2Int>();
-        q.Enqueue(s); visited[s.x, s.y] = true;
-        var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
-
-        bool reached = false;
-        while (q.Count > 0 && !tok.IsCancellationRequested)
-        {
-            int layerCount = q.Count;
-            var next = new List<Vector2Int>();
-            for (int i = 0; i < layerCount; i++)
-            {
-                var cell = q.Dequeue();
-                visitQueues[idx].Enqueue(cell);
-                if (cell == g) { reached = true; break; }
-                foreach (var d in dirs)
-                {
-                    var np = cell + d;
-                    if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
-                    if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
-                    visited[np.x, np.y] = true;
-                    parent[np] = cell;
-                    next.Add(np);
-                }
-            }
-            if (reached) break;
-            foreach (var c in next) q.Enqueue(c);
-        }
-
-        if (reached)
-        {
-            // mark winner
-            if (winnerIdx < 0) winnerIdx = idx;
-            // reconstruct path
-            var path = new List<Vector2Int>();
-            var cur = g;
-            while (cur != s)
-            {
-                path.Add(cur);
-                cur = parent[cur];
-            }
-            path.Add(s);
-            path.Reverse();
-            foreach (var c in path)
-                pathQueues[idx].Enqueue(c);
-            cts.Cancel();
-        }
-    }
-
-    // 2) DFS
-    void RunDFS(int idx, int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok)
-    {
-        int W = maze.GetLength(0), H = maze.GetLength(1);
-        var visited = new bool[W, H];
-        var parent = new Dictionary<Vector2Int, Vector2Int>();
-        var stack = new Stack<Vector2Int>();
-        stack.Push(s); visited[s.x, s.y] = true;
-        var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
-
-        bool reached = false;
-        while (stack.Count > 0 && !tok.IsCancellationRequested)
-        {
-            var cell = stack.Pop();
-            visitQueues[idx].Enqueue(cell);
-            if (cell == g) { reached = true; break; }
-
-            var rd = dirs.OrderBy(_ => Guid.NewGuid()).ToArray();
-            foreach (var d in rd)
-            {
-                var np = cell + d;
-                if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
-                if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
-                visited[np.x, np.y] = true;
-                parent[np] = cell;
-                stack.Push(np);
-            }
-        }
-
-        if (reached)
-        {
-            if (winnerIdx < 0) winnerIdx = idx;
-            var path = new List<Vector2Int>();
-            var cur = g;
-            while (cur != s)
-            {
-                path.Add(cur);
-                cur = parent[cur];
-            }
-            path.Add(s);
-            path.Reverse();
-            foreach (var c in path)
-                pathQueues[idx].Enqueue(c);
-            cts.Cancel();
-        }
-    }
-
-    // 3) Greedy Best-First
-    void RunGreedy(int idx, int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok)
-    {
-        int W = maze.GetLength(0), H = maze.GetLength(1);
-        var visited = new bool[W, H];
-        var parent = new Dictionary<Vector2Int, Vector2Int>();
-        var pq = new SortedSet<(int, Vector2Int)>(
-            Comparer<(int, Vector2Int)>.Create((a, b) =>
-            {
-                int diff = a.Item1 - b.Item1; if (diff != 0) return diff;
-                diff = a.Item2.x - b.Item2.x; if (diff != 0) return diff;
-                return a.Item2.y - b.Item2.y;
-            })
-        );
-        visited[s.x, s.y] = true;
-        pq.Add((Mathf.Abs(s.x - g.x) + Mathf.Abs(s.y - g.y), s));
-
-        bool reached = false;
-        var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
-        while (pq.Count > 0 && !reached && !tok.IsCancellationRequested)
-        {
-            var top = pq.Min; pq.Remove(top);
-            var cell = top.Item2;
-            visitQueues[idx].Enqueue(cell);
-            if (cell == g) { reached = true; break; }
-
-            foreach (var d in dirs)
-            {
-                var np = cell + d;
-                if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
-                if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
-                visited[np.x, np.y] = true;
-                parent[np] = cell;
-                int h = Mathf.Abs(np.x - g.x) + Mathf.Abs(np.y - g.y);
-                pq.Add((h, np));
-            }
-        }
-
-        if (reached)
-        {
-            if (winnerIdx < 0) winnerIdx = idx;
-            var path = new List<Vector2Int>();
-            var cur = g;
-            while (cur != s)
-            {
-                path.Add(cur);
-                cur = parent[cur];
-            }
-            path.Add(s);
-            path.Reverse();
-            foreach (var c in path)
-                pathQueues[idx].Enqueue(c);
-            cts.Cancel();
-        }
-    }
-
-    // 4) Random-Walk + Backtrack
-    void RunRandomWalk(int idx, int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok)
-    {
-        int W = maze.GetLength(0), H = maze.GetLength(1);
-        var visited = new bool[W, H];
-        var parent = new Dictionary<Vector2Int, Vector2Int>();
-        var stack = new Stack<Vector2Int>();
-        stack.Push(s); visited[s.x, s.y] = true;
-        var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
-        var rnd = new System.Random(idx * 999);
-
-        bool reached = false;
-        while (stack.Count > 0 && !reached && !tok.IsCancellationRequested)
-        {
-            var cell = stack.Peek();
-            visitQueues[idx].Enqueue(cell);
-            if (cell == g) { reached = true; break; }
-
-            var rd = dirs.OrderBy(_ => rnd.Next()).ToArray();
-            bool moved = false;
-            foreach (var d in rd)
-            {
-                var np = cell + d;
-                if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
-                if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
-                visited[np.x, np.y] = true;
-                parent[np] = cell;
-                stack.Push(np);
-                moved = true;
-                break;
-            }
-            if (!moved) stack.Pop();
-        }
-
-        if (reached)
-        {
-            if (winnerIdx < 0) winnerIdx = idx;
-            var path = new List<Vector2Int>();
-            var cur = g;
-            while (cur != s)
-            {
-                path.Add(cur);
-                cur = parent[cur];
-            }
-            path.Add(s);
-            path.Reverse();
-            foreach (var c in path)
-                pathQueues[idx].Enqueue(c);
-            cts.Cancel();
-        }
-    }
-
-    // 5) A* Search (f = g + h, g maliyeti, cell = Item3)
-    void RunAStar(int idx, int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok)
-    {
-        int W = maze.GetLength(0), H = maze.GetLength(1);
-        var visited = new bool[W, H];
-        var parent = new Dictionary<Vector2Int, Vector2Int>();
-        var gScore = new Dictionary<Vector2Int, int> { [s] = 0 };
-
-        // open set: (f, g, cell)
-        var open = new SortedSet<(int, int, Vector2Int)>(
-            Comparer<(int, int, Vector2Int)>.Create((a, b) =>
-            {
-                // önce f karşılaştır
-                int diff = a.Item1 - b.Item1;
-                if (diff != 0) return diff;
-                // sonra g karşılaştır
-                diff = a.Item2 - b.Item2;
-                if (diff != 0) return diff;
-                // tie-break: x sonra y
-                diff = a.Item3.x - b.Item3.x;
-                if (diff != 0) return diff;
-                return a.Item3.y - b.Item3.y;
-            })
-        );
-
-        // başlangıç
-        visited[s.x, s.y] = true;
-        int h0 = Mathf.Abs(s.x - g.x) + Mathf.Abs(s.y - g.y);
-        open.Add((h0 + 0, 0, s));
-
-        var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
-        bool reached = false;
-
-        while (open.Count > 0 && !reached && !tok.IsCancellationRequested)
-        {
-            var top = open.Min; open.Remove(top);
-            var cell = top.Item3;
-            visitQueues[idx].Enqueue(cell);
-
-            if (cell == g) { reached = true; break; }
-
-            foreach (var d in dirs)
-            {
-                var np = cell + d;
-                if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
-                if (maze[np.x, np.y] == 1) continue;
-
-                int tentativeG = top.Item2 + 1;
-                if (!gScore.TryGetValue(np, out var prevG) || tentativeG < prevG)
-                {
-                    gScore[np] = tentativeG;
-                    parent[np] = cell;
-                    int h = Mathf.Abs(np.x - g.x) + Mathf.Abs(np.y - g.y);
-                    open.Add((tentativeG + h, tentativeG, np));
-                    visited[np.x, np.y] = true;
-                }
-            }
-        }
-
-        if (reached)
-        {
-            if (winnerIdx < 0) winnerIdx = idx;
-            var path = new List<Vector2Int>();
-            var cur = g;
-            while (cur != s)
-            {
-                path.Add(cur);
-                cur = parent[cur];
-            }
-            path.Add(s);
-            path.Reverse();
-            foreach (var c in path)
-                pathQueues[idx].Enqueue(c);
-            cts.Cancel();
-        }
-    }
 
     IEnumerator Animate(int idx)
     {

--- a/Assets/Scripts/Pathfinding/AStarSolver.cs
+++ b/Assets/Scripts/Pathfinding/AStarSolver.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class AStarSolver : IPathSolver
+{
+    public Task Solve(int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok,
+                      ConcurrentQueue<Vector2Int> visits,
+                      ConcurrentQueue<Vector2Int> path)
+    {
+        return Task.Run(() =>
+        {
+            int W = maze.GetLength(0), H = maze.GetLength(1);
+            var visited = new bool[W, H];
+            var parent = new Dictionary<Vector2Int, Vector2Int>();
+            var gScore = new Dictionary<Vector2Int, int> { [s] = 0 };
+            var open = new SortedSet<(int, int, Vector2Int)>(
+                Comparer<(int, int, Vector2Int)>.Create((a, b) =>
+                {
+                    int diff = a.Item1 - b.Item1; if (diff != 0) return diff;
+                    diff = a.Item2 - b.Item2; if (diff != 0) return diff;
+                    diff = a.Item3.x - b.Item3.x; if (diff != 0) return diff;
+                    return a.Item3.y - b.Item3.y;
+                })
+            );
+            visited[s.x, s.y] = true;
+            int h0 = Mathf.Abs(s.x - g.x) + Mathf.Abs(s.y - g.y);
+            open.Add((h0, 0, s));
+            var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
+            bool reached = false;
+            while (open.Count > 0 && !reached && !tok.IsCancellationRequested)
+            {
+                var top = open.Min; open.Remove(top);
+                var cell = top.Item3;
+                visits.Enqueue(cell);
+                if (cell == g) { reached = true; break; }
+                foreach (var d in dirs)
+                {
+                    var np = cell + d;
+                    if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
+                    if (maze[np.x, np.y] == 1) continue;
+                    int tentativeG = top.Item2 + 1;
+                    if (!gScore.TryGetValue(np, out var prevG) || tentativeG < prevG)
+                    {
+                        gScore[np] = tentativeG;
+                        parent[np] = cell;
+                        int h = Mathf.Abs(np.x - g.x) + Mathf.Abs(np.y - g.y);
+                        open.Add((tentativeG + h, tentativeG, np));
+                        visited[np.x, np.y] = true;
+                    }
+                }
+            }
+            if (reached)
+            {
+                var cur = g;
+                var list = new List<Vector2Int>();
+                while (cur != s)
+                {
+                    list.Add(cur);
+                    cur = parent[cur];
+                }
+                list.Add(s);
+                list.Reverse();
+                foreach (var c in list) path.Enqueue(c);
+            }
+        }, tok);
+    }
+}

--- a/Assets/Scripts/Pathfinding/AStarSolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/AStarSolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1dc113c8f5ea4e5fa9d8dd1ccac647fa

--- a/Assets/Scripts/Pathfinding/BfsSolver.cs
+++ b/Assets/Scripts/Pathfinding/BfsSolver.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class BfsSolver : IPathSolver
+{
+    public Task Solve(int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok,
+                      ConcurrentQueue<Vector2Int> visits,
+                      ConcurrentQueue<Vector2Int> path)
+    {
+        return Task.Run(() =>
+        {
+            int W = maze.GetLength(0), H = maze.GetLength(1);
+            var visited = new bool[W, H];
+            var parent = new Dictionary<Vector2Int, Vector2Int>();
+            var q = new Queue<Vector2Int>();
+            q.Enqueue(s); visited[s.x, s.y] = true;
+            var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
+            bool reached = false;
+            while (q.Count > 0 && !tok.IsCancellationRequested)
+            {
+                int layerCount = q.Count;
+                var next = new List<Vector2Int>();
+                for (int i = 0; i < layerCount; i++)
+                {
+                    var cell = q.Dequeue();
+                    visits.Enqueue(cell);
+                    if (cell == g) { reached = true; break; }
+                    foreach (var d in dirs)
+                    {
+                        var np = cell + d;
+                        if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
+                        if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
+                        visited[np.x, np.y] = true;
+                        parent[np] = cell;
+                        next.Add(np);
+                    }
+                }
+                if (reached) break;
+                foreach (var c in next) q.Enqueue(c);
+            }
+            if (reached)
+            {
+                var cur = g;
+                var list = new List<Vector2Int>();
+                while (cur != s)
+                {
+                    list.Add(cur);
+                    cur = parent[cur];
+                }
+                list.Add(s);
+                list.Reverse();
+                foreach (var c in list) path.Enqueue(c);
+            }
+        }, tok);
+    }
+}

--- a/Assets/Scripts/Pathfinding/BfsSolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/BfsSolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ab031a40a18477b9632a5c7fe7856bc

--- a/Assets/Scripts/Pathfinding/DfsSolver.cs
+++ b/Assets/Scripts/Pathfinding/DfsSolver.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class DfsSolver : IPathSolver
+{
+    public Task Solve(int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok,
+                      ConcurrentQueue<Vector2Int> visits,
+                      ConcurrentQueue<Vector2Int> path)
+    {
+        return Task.Run(() =>
+        {
+            int W = maze.GetLength(0), H = maze.GetLength(1);
+            var visited = new bool[W, H];
+            var parent = new Dictionary<Vector2Int, Vector2Int>();
+            var stack = new Stack<Vector2Int>();
+            stack.Push(s); visited[s.x, s.y] = true;
+            var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
+            bool reached = false;
+            while (stack.Count > 0 && !tok.IsCancellationRequested)
+            {
+                var cell = stack.Pop();
+                visits.Enqueue(cell);
+                if (cell == g) { reached = true; break; }
+                var rd = dirs.OrderBy(_ => Guid.NewGuid()).ToArray();
+                foreach (var d in rd)
+                {
+                    var np = cell + d;
+                    if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
+                    if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
+                    visited[np.x, np.y] = true;
+                    parent[np] = cell;
+                    stack.Push(np);
+                }
+            }
+            if (reached)
+            {
+                var cur = g;
+                var list = new List<Vector2Int>();
+                while (cur != s)
+                {
+                    list.Add(cur);
+                    cur = parent[cur];
+                }
+                list.Add(s);
+                list.Reverse();
+                foreach (var c in list) path.Enqueue(c);
+            }
+        }, tok);
+    }
+}

--- a/Assets/Scripts/Pathfinding/DfsSolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/DfsSolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a3b9993ddf4426dab5100fe8ddabe84

--- a/Assets/Scripts/Pathfinding/GreedySolver.cs
+++ b/Assets/Scripts/Pathfinding/GreedySolver.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class GreedySolver : IPathSolver
+{
+    public Task Solve(int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok,
+                      ConcurrentQueue<Vector2Int> visits,
+                      ConcurrentQueue<Vector2Int> path)
+    {
+        return Task.Run(() =>
+        {
+            int W = maze.GetLength(0), H = maze.GetLength(1);
+            var visited = new bool[W, H];
+            var parent = new Dictionary<Vector2Int, Vector2Int>();
+            var pq = new SortedSet<(int, Vector2Int)>(
+                Comparer<(int, Vector2Int)>.Create((a, b) =>
+                {
+                    int diff = a.Item1 - b.Item1; if (diff != 0) return diff;
+                    diff = a.Item2.x - b.Item2.x; if (diff != 0) return diff;
+                    return a.Item2.y - b.Item2.y;
+                })
+            );
+            visited[s.x, s.y] = true;
+            pq.Add((Mathf.Abs(s.x - g.x) + Mathf.Abs(s.y - g.y), s));
+            bool reached = false;
+            var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
+            while (pq.Count > 0 && !reached && !tok.IsCancellationRequested)
+            {
+                var top = pq.Min; pq.Remove(top);
+                var cell = top.Item2;
+                visits.Enqueue(cell);
+                if (cell == g) { reached = true; break; }
+                foreach (var d in dirs)
+                {
+                    var np = cell + d;
+                    if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
+                    if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
+                    visited[np.x, np.y] = true;
+                    parent[np] = cell;
+                    int h = Mathf.Abs(np.x - g.x) + Mathf.Abs(np.y - g.y);
+                    pq.Add((h, np));
+                }
+            }
+            if (reached)
+            {
+                var cur = g;
+                var list = new List<Vector2Int>();
+                while (cur != s)
+                {
+                    list.Add(cur);
+                    cur = parent[cur];
+                }
+                list.Add(s);
+                list.Reverse();
+                foreach (var c in list) path.Enqueue(c);
+            }
+        }, tok);
+    }
+}

--- a/Assets/Scripts/Pathfinding/GreedySolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/GreedySolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e8af5bd9edc24ac4afad4fd637e928b0

--- a/Assets/Scripts/Pathfinding/IPathSolver.cs
+++ b/Assets/Scripts/Pathfinding/IPathSolver.cs
@@ -1,0 +1,12 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public interface IPathSolver
+{
+    Task Solve(int[,] maze, Vector2Int start, Vector2Int goal,
+               CancellationToken token,
+               ConcurrentQueue<Vector2Int> visits,
+               ConcurrentQueue<Vector2Int> path);
+}

--- a/Assets/Scripts/Pathfinding/IPathSolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/IPathSolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1368a048ad574ccd861feb4c1717b83a

--- a/Assets/Scripts/Pathfinding/RandomWalkSolver.cs
+++ b/Assets/Scripts/Pathfinding/RandomWalkSolver.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class RandomWalkSolver : IPathSolver
+{
+    public Task Solve(int[,] maze, Vector2Int s, Vector2Int g, CancellationToken tok,
+                      ConcurrentQueue<Vector2Int> visits,
+                      ConcurrentQueue<Vector2Int> path)
+    {
+        return Task.Run(() =>
+        {
+            int W = maze.GetLength(0), H = maze.GetLength(1);
+            var visited = new bool[W, H];
+            var parent = new Dictionary<Vector2Int, Vector2Int>();
+            var stack = new Stack<Vector2Int>();
+            stack.Push(s); visited[s.x, s.y] = true;
+            var dirs = new[] { Vector2Int.up, Vector2Int.right, Vector2Int.down, Vector2Int.left };
+            var rnd = new System.Random(999);
+            bool reached = false;
+            while (stack.Count > 0 && !reached && !tok.IsCancellationRequested)
+            {
+                var cell = stack.Peek();
+                visits.Enqueue(cell);
+                if (cell == g) { reached = true; break; }
+                var rd = dirs.OrderBy(_ => rnd.Next()).ToArray();
+                bool moved = false;
+                foreach (var d in rd)
+                {
+                    var np = cell + d;
+                    if (np.x < 0 || np.x >= W || np.y < 0 || np.y >= H) continue;
+                    if (maze[np.x, np.y] == 1 || visited[np.x, np.y]) continue;
+                    visited[np.x, np.y] = true;
+                    parent[np] = cell;
+                    stack.Push(np);
+                    moved = true;
+                    break;
+                }
+                if (!moved) stack.Pop();
+            }
+            if (reached)
+            {
+                var cur = g;
+                var list = new List<Vector2Int>();
+                while (cur != s)
+                {
+                    list.Add(cur);
+                    cur = parent[cur];
+                }
+                list.Add(s);
+                list.Reverse();
+                foreach (var c in list) path.Enqueue(c);
+            }
+        }, tok);
+    }
+}

--- a/Assets/Scripts/Pathfinding/RandomWalkSolver.cs.meta
+++ b/Assets/Scripts/Pathfinding/RandomWalkSolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f47d27ff2634ea6aa9c87edb03ab53c


### PR DESCRIPTION
## Summary
- add `IPathSolver` interface
- implement BFS/DFS/Greedy/RandomWalk/AStar solvers in new Pathfinding folder
- refactor `MultiStrategyAnimator` to discover `IPathSolver` implementations and run them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684217b6b2948329b717e168967afe99